### PR TITLE
bug fix na rota de termo

### DIFF
--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Aluno.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Aluno.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -45,6 +47,7 @@ public class Aluno extends Pessoa implements Serializable {
 	@Column(name = "dataNascimento")
 	private Date dataNascimento;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="curso_id", referencedColumnName="id", nullable=true)
 	private Curso curso;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Apolice.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Apolice.java
@@ -1,7 +1,9 @@
-package br.ufpr.estagio.modulo.model;
+	package br.ufpr.estagio.modulo.model;
 
 import java.io.Serializable;
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -35,6 +37,7 @@ public class Apolice implements Serializable {
 	@Column(name = "dataFim")
 	private Date dataFim;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="seguradora_id", referencedColumnName="id", nullable=true)
 	private Seguradora seguradora;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Convenio.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Convenio.java
@@ -3,6 +3,8 @@ package br.ufpr.estagio.modulo.model;
 import java.io.Serializable;
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -37,6 +39,7 @@ public class Convenio implements Serializable{
 	@Column(name = "dataFim")
 	private Date dataFim;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="agente_integrador_id", referencedColumnName="id", nullable=true)
 	private AgenteIntegrador agenteIntegrador;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Coordenador.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Coordenador.java
@@ -2,6 +2,9 @@ package br.ufpr.estagio.modulo.model;
 
 import java.io.Serializable;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.List;
 
 import jakarta.persistence.CascadeType;
@@ -30,6 +33,7 @@ public class Coordenador extends Pessoa implements Serializable{
 	@Column(name = "cpf")
 	private String cpf;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="curso_id", referencedColumnName="id", nullable=true)
 	private Curso curso;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Disciplina.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Disciplina.java
@@ -2,6 +2,9 @@ package br.ufpr.estagio.modulo.model;
 
 import java.io.Serializable;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.List;
 
 import jakarta.persistence.CascadeType;
@@ -36,6 +39,7 @@ public class Disciplina implements Serializable{
 	)
 	private List<Aluno> aluno;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="curso_id", referencedColumnName="id", nullable=true)
 	private Curso curso;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Estagio.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/Estagio.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import org.springframework.hateoas.RepresentationModel;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.*;
 
 import br.ufpr.estagio.modulo.enums.EnumStatusEstagio;
@@ -32,14 +34,17 @@ public class Estagio extends RepresentationModel<Estagio> implements Serializabl
 	@Column(name = "estagio_ufpr")
 	private boolean estagioUfpr;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="aluno_id", referencedColumnName="id", nullable=true)
 	private Aluno aluno;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="contratante_id", referencedColumnName="id", nullable=true)
 	private Contratante contratante;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="seguradora_id", referencedColumnName="id", nullable=true)
 	private Seguradora seguradora;
@@ -48,14 +53,17 @@ public class Estagio extends RepresentationModel<Estagio> implements Serializabl
 	@JoinColumn(name="apolice_id", referencedColumnName="id",nullable=true)
 	private Apolice apolice;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="agente_integrador_id", referencedColumnName="id", nullable=true)
 	private AgenteIntegrador agenteIntegrador;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="orientador_id", referencedColumnName="id", nullable=true)
 	private Orientador orientador;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="supervisor_id", referencedColumnName="id", nullable=true)
 	private Supervisor supervisor;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/PeriodoRecesso.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/PeriodoRecesso.java
@@ -3,6 +3,8 @@ package br.ufpr.estagio.modulo.model;
 import java.io.Serializable;
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,6 +33,7 @@ public class PeriodoRecesso implements Serializable{
 	@Column(name = "dataFim")
 	private Date dataFim;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="termo_de_rescisao_id", referencedColumnName="id", nullable=true)
 	private TermoDeRescisao termoRescisao;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/PlanoDeAtividades.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/PlanoDeAtividades.java
@@ -2,6 +2,8 @@ package br.ufpr.estagio.modulo.model;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -28,6 +30,7 @@ public class PlanoDeAtividades implements Serializable{
 	@Column(name = "local")
 	private String local;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="supervisor_id", referencedColumnName="id", nullable=true)
 	private Supervisor supervisor;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/RelatorioDeEstagio.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/RelatorioDeEstagio.java
@@ -2,6 +2,8 @@ package br.ufpr.estagio.modulo.model;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import br.ufpr.estagio.modulo.enums.EnumAvaliacao;
 import br.ufpr.estagio.modulo.enums.EnumAvaliacaoAtividades;
 import br.ufpr.estagio.modulo.enums.EnumTipoRelatorio;
@@ -18,6 +20,7 @@ public class RelatorioDeEstagio implements Serializable{
 	@Column(name = "id")
 	private long id;
 
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="estagio_id", referencedColumnName="id",nullable=true)
 	private Estagio estagio;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/TermoDeEstagio.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/TermoDeEstagio.java
@@ -5,6 +5,8 @@ import java.sql.Date;
 
 import org.springframework.hateoas.RepresentationModel;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.*;
 
 import br.ufpr.estagio.modulo.enums.EnumEtapaFluxo;
@@ -26,10 +28,12 @@ public class TermoDeEstagio extends RepresentationModel<TermoDeEstagio> implemen
 	@Column(name = "tipo_termo_de_estagio")
 	private EnumTipoTermoDeEstagio tipoTermoDeEstagio;
 	
+	@JsonIgnore
 	@ManyToOne(cascade= {CascadeType.REMOVE, CascadeType.PERSIST})
 	@JoinColumn(name="estagio_id", referencedColumnName="id",nullable=true)
 	private Estagio estagio;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="seguradora_id", referencedColumnName="id", nullable=true)
 	private Seguradora seguradora;
@@ -38,18 +42,22 @@ public class TermoDeEstagio extends RepresentationModel<TermoDeEstagio> implemen
 	@JoinColumn(name="apolice_id", referencedColumnName="id",nullable=true)
 	private Apolice apolice;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="agente_integrador_id", referencedColumnName="id", nullable=true)
 	private AgenteIntegrador agenteIntegrador;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="orientador_id", referencedColumnName="id", nullable=true)
 	private Orientador orientador;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="supervisor_id", referencedColumnName="id", nullable=true)
 	private Supervisor supervisor;
 	
+	@JsonIgnore
 	@ManyToOne(cascade=CascadeType.REMOVE)
 	@JoinColumn(name="coordenador_id", referencedColumnName="id", nullable=true)
 	private Coordenador coordenador;


### PR DESCRIPTION
Foi adicionada a annotation @JsonIgnore nas relações @ManyToOne com a finalidade de corrigir um erro que estava ocorrendo quando se tentava listar um termo em específico ou listar todos os termos. Referência do bug fix: https://stackoverflow.com/questions/20813496/tomcat-exception-cannot-call-senderror-after-the-response-has-been-committed