### PR TITLE
backend: fix espelhar infos do estagio

### DIFF
--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/TermoDeEstagioService.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/TermoDeEstagioService.java
@@ -672,7 +672,7 @@ public class TermoDeEstagioService {
 		EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Aluno;
 		
 		TermoDeEstagio termoAditivo = new TermoDeEstagio();
-		BeanUtils.copyProperties(estagio.getTermoDeCompromisso(), termoAditivo);
+		BeanUtils.copyProperties(estagio, termoAditivo);
 		
 		TermoDeEstagio termoAditivoTemp = new TermoDeEstagio();
 		termoAditivoTemp = termoRepo.save(termoAditivoTemp);
@@ -690,7 +690,7 @@ public class TermoDeEstagioService {
 		termoAditivo.setMotivoIndeferimento(termoAditivoTemp.getMotivoIndeferimento());
 		
 		PlanoDeAtividades planoAtividade = new PlanoDeAtividades();
-		BeanUtils.copyProperties(estagio.getTermoDeCompromisso().getPlanoAtividades(), planoAtividade);
+		BeanUtils.copyProperties(estagio.getPlanoDeAtividades(), planoAtividade);
 		
 		PlanoDeAtividades planoAtividadeTemp = new PlanoDeAtividades();
 		planoAtividadeTemp = planoRepo.save(planoAtividadeTemp);


### PR DESCRIPTION
Implementado correção para que inicialmente o termo aditivo espelhe as informacoes do estagio e nao do termo de compromisso.