### PR TITLE
backend: TermoDeRescisao

### DIFF
--- a/TCC-Estagio.postman_collection.json
+++ b/TCC-Estagio.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "d32c7e71-1149-4e75-a8e3-5e0b1136e47a",
+		"_postman_id": "f6f8cb31-81bb-4974-a4ba-8f75fb3ce1a3",
 		"name": "TCC-Estagio",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "17301767"
+		"_exporter_id": "18567474"
 	},
 	"item": [
 		{
@@ -292,6 +292,151 @@
 							"port": "5000",
 							"path": [
 								"termo",
+								"102"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "TermoDeRescisao",
+			"item": [
+				{
+					"name": "NãoUsar-novoTermoDeRescisao",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"dataTermino\": \"2023-12-05\", \r\n    \"periodoTotalRecesso\": 120\r\n}"
+						},
+						"url": {
+							"raw": "http://localhost:5000/termoDeRescisao",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "5000",
+							"path": [
+								"termoDeRescisao"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "listTermosDeRescisao",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:5000/termoDeRescisao",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "5000",
+							"path": [
+								"termoDeRescisao"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "listTermoDeRescisao",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:5000/termoDeRescisao/2",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "5000",
+							"path": [
+								"termoDeRescisao",
+								"2"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateTermoDeRescisao",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"dataTermino\": \"2023-12-05\", \r\n    \"periodoTotalRecesso\": 120\r\n}"
+						},
+						"url": {
+							"raw": "http://localhost:5000/termoDeRescisao/2",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "5000",
+							"path": [
+								"termoDeRescisao",
+								"2"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "NãoUsar-deleteTermoDeRescisao",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:5000/termoDeRescisao/102",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "5000",
+							"path": [
+								"termoDeRescisao",
 								"102"
 							]
 						}
@@ -689,6 +834,172 @@
 											"key": "statusTermo",
 											"value": "Aprovado"
 										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "TermoDeRescisao",
+					"item": [
+						{
+							"name": "novoTermoDeRescisao",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/aluno/GRR20175486/estagio/1/termoRescisao",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"aluno",
+										"GRR20175486",
+										"estagio",
+										"1",
+										"termoRescisao"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "listarTermosDeRescisaoPorAluno",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/aluno/GRR20175486/termoDeRescisao/",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"aluno",
+										"GRR20175486",
+										"termoDeRescisao",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "listarTermoDeRescisaoEtapaAlunoPorAluno",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/aluno/GRR20175486/termoDeRescisao/etapaAluno",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"aluno",
+										"GRR20175486",
+										"termoDeRescisao",
+										"etapaAluno"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "listarTermosDeRecisaoPorAlunoEmProcessoDeCiencia",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/aluno/GRR20175486/termoDeRescisao/etapaCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"aluno",
+										"GRR20175486",
+										"termoDeRescisao",
+										"etapaCiencia"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "listarTermosDeRecisaoPorAlunoProcessoFinalizado",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/aluno/GRR20175486/termoDeRescisao/finalizados",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"aluno",
+										"GRR20175486",
+										"termoDeRescisao",
+										"finalizados"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "solicitarCienciaTermoDeRescisao",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/aluno/GRR20175486/estagio/1/termoDeRescisao/2/solicitarCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"aluno",
+										"GRR20175486",
+										"estagio",
+										"1",
+										"termoDeRescisao",
+										"2",
+										"solicitarCiencia"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "cancelarTermoAditivo",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/aluno/GRR20175486/estagio/1/termoDeRescisao/1/cancelarTermoDeRescisao",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"aluno",
+										"GRR20175486",
+										"estagio",
+										"1",
+										"termoDeRescisao",
+										"1",
+										"cancelarTermoDeRescisao"
 									]
 								}
 							},
@@ -3043,6 +3354,54 @@
 					]
 				},
 				{
+					"name": "TermoDeRescisao",
+					"item": [
+						{
+							"name": "listarTermosDeRescisaoPendenteCienciaCoe",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coe/termoDeRescisao/pendenteCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coe",
+										"termoDeRescisao",
+										"pendenteCiencia"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "darCienciaTermoDeRescisaoCoe",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coe/termoDeRescisao/2/darCienciaCoe",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coe",
+										"termoDeRescisao",
+										"2",
+										"darCienciaCoe"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
 					"name": "CertificadoDeEstagio",
 					"item": [
 						{
@@ -3122,118 +3481,123 @@
 					]
 				},
 				{
-					"name": "indeferirTermoCoe",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"justificativa\": \"Não pode fazer estágio porque não pode.\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
+					"name": "TermoDeEstagio",
+					"item": [
+						{
+							"name": "indeferirTermoCoe",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"justificativa\": \"Não pode fazer estágio porque não pode.\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coe/termo/16/indeferir",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coe",
+										"termo",
+										"16",
+										"indeferir"
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "http://localhost:5000/coe/termo/16/indeferir",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coe",
-								"termo",
-								"16",
-								"indeferir"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "solicitarAjutesTermoCoe",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"descricaoAjustes\": \"Precisa alterar isso, isso e aquilo.\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
+						{
+							"name": "solicitarAjutesTermoCoe",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"descricaoAjustes\": \"Precisa alterar isso, isso e aquilo.\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coe/termo/13/solicitarAjustes",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coe",
+										"termo",
+										"13",
+										"solicitarAjustes"
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "http://localhost:5000/coe/termo/13/solicitarAjustes",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coe",
-								"termo",
-								"13",
-								"solicitarAjustes"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "aprovarTermoCoe",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
+						{
+							"name": "aprovarTermoCoe",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coe/termo/18/aprovar",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coe",
+										"termo",
+										"18",
+										"aprovar"
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "http://localhost:5000/coe/termo/18/aprovar",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coe",
-								"termo",
-								"18",
-								"aprovar"
-							]
+						{
+							"name": "baixarTermoAluno",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coe/GRR20204481/download-termo",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coe",
+										"GRR20204481",
+										"download-termo"
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
-				},
-				{
-					"name": "baixarTermoAluno",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coe/GRR20204481/download-termo",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coe",
-								"GRR20204481",
-								"download-termo"
-							]
-						}
-					},
-					"response": []
+					]
 				}
 			]
 		},
@@ -3431,242 +3795,295 @@
 					]
 				},
 				{
-					"name": "darCienciaFormacaoSupervisor",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
+					"name": "TermoDeEstagio",
+					"item": [
+						{
+							"name": "darCienciaFormacaoSupervisor",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/termo/13/cienciaFormacaoSupervisor",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"termo",
+										"13",
+										"cienciaFormacaoSupervisor"
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "http://localhost:5000/coordenacao/termo/13/cienciaFormacaoSupervisor",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coordenacao",
-								"termo",
-								"13",
-								"cienciaFormacaoSupervisor"
-							]
+						{
+							"name": "darCienciaPlanoAtividades",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/termo/13/cienciaPlanoAtividades",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"termo",
+										"13",
+										"cienciaPlanoAtividades"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "darCienciaIRA",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/termo/13/cienciaIra",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"termo",
+										"13",
+										"cienciaIra"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "indeferirTermoCoordenacao",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"justificativa\": \"Não pode fazer estágio porque não pode.\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/termo/3/indeferir",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"termo",
+										"3",
+										"indeferir"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "solicitarAjutesTermoCoordenacao",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"descricaoAjustes\": \"Precisa alterar isso, isso e aquilo.\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/termo/13/solicitarAjustes",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"termo",
+										"13",
+										"solicitarAjustes"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "aprovarTermoCoordenacao",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/termo/17/aprovar",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"termo",
+										"17",
+										"aprovar"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "darCienciaTermoIndeferido",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/termo/13/cienciaIndeferimento",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"termo",
+										"13",
+										"cienciaIndeferimento"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "baixarTermoAluno",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/GRR20204481/download-termo",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"GRR20204481",
+										"download-termo"
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
+					]
 				},
 				{
-					"name": "darCienciaPlanoAtividades",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
+					"name": "TermoDeRescisao",
+					"item": [
+						{
+							"name": "listarTermosDeRescisaoPendenteCienciaCoordenacao",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/termoDeRescisao/pendenteCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"termoDeRescisao",
+										"pendenteCiencia"
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "http://localhost:5000/coordenacao/termo/13/cienciaPlanoAtividades",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coordenacao",
-								"termo",
-								"13",
-								"cienciaPlanoAtividades"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "darCienciaIRA",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
+						{
+							"name": "darCienciaTermoDeRescisaoCoordenacao",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coordenacao/termoDeRescisao/2/darCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coordenacao",
+										"termoDeRescisao",
+										"2",
+										"darCiencia"
+									]
 								}
-							}
-						},
-						"url": {
-							"raw": "http://localhost:5000/coordenacao/termo/13/cienciaIra",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coordenacao",
-								"termo",
-								"13",
-								"cienciaIra"
-							]
+							},
+							"response": []
 						}
-					},
-					"response": []
-				},
-				{
-					"name": "indeferirTermoCoordenacao",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"justificativa\": \"Não pode fazer estágio porque não pode.\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://localhost:5000/coordenacao/termo/3/indeferir",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coordenacao",
-								"termo",
-								"3",
-								"indeferir"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "solicitarAjutesTermoCoordenacao",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"descricaoAjustes\": \"Precisa alterar isso, isso e aquilo.\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://localhost:5000/coordenacao/termo/13/solicitarAjustes",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coordenacao",
-								"termo",
-								"13",
-								"solicitarAjustes"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "aprovarTermoCoordenacao",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://localhost:5000/coordenacao/termo/17/aprovar",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coordenacao",
-								"termo",
-								"17",
-								"aprovar"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "darCienciaTermoIndeferido",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://localhost:5000/coordenacao/termo/13/cienciaIndeferimento",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coordenacao",
-								"termo",
-								"13",
-								"cienciaIndeferimento"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "baixarTermoAluno",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coordenacao/GRR20204481/download-termo",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coordenacao",
-								"GRR20204481",
-								"download-termo"
-							]
-						}
-					},
-					"response": []
+					]
 				}
 			]
 		},
@@ -3822,266 +4239,324 @@
 					]
 				},
 				{
-					"name": "consultarAgenteIntegradorAssociadoAoTermo",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coafe/termo/13/agenteIntegrador",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"termo",
-								"13",
-								"agenteIntegrador"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "consultarSeguradoraAssociadaAoTermo",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coafe/termo/13/seguradora",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"termo",
-								"13",
-								"seguradora"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "consultarApoliceAssociadaAoTermo",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coafe/termo/13/apolice",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"termo",
-								"13",
-								"apolice"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "indeferirTermoCoafe",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"justificativa\": \"Não pode fazer estágio porque não pode.\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
+					"name": "TermoDeEstagio",
+					"item": [
+						{
+							"name": "consultarAgenteIntegradorAssociadoAoTermo",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/termo/13/agenteIntegrador",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"termo",
+										"13",
+										"agenteIntegrador"
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "http://localhost:5000/coafe/termo/13/indeferir",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"termo",
-								"13",
-								"indeferir"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "solicitarAjutesTermoCoafe",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"descricaoAjustes\": \"Precisa alterar isso, isso e aquilo.\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
+						{
+							"name": "consultarSeguradoraAssociadaAoTermo",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/termo/13/seguradora",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"termo",
+										"13",
+										"seguradora"
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "http://localhost:5000/coafe/termo/1/solicitarAjustes",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"termo",
-								"1",
-								"solicitarAjustes"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "aprovarTermoCoafe",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
+						{
+							"name": "consultarApoliceAssociadaAoTermo",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/termo/13/apolice",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"termo",
+										"13",
+										"apolice"
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "http://localhost:5000/coafe/termo/13/aprovar",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"termo",
-								"13",
-								"aprovar"
-							]
+						{
+							"name": "indeferirTermoCoafe",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"justificativa\": \"Não pode fazer estágio porque não pode.\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coafe/termo/13/indeferir",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"termo",
+										"13",
+										"indeferir"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "solicitarAjutesTermoCoafe",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"descricaoAjustes\": \"Precisa alterar isso, isso e aquilo.\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coafe/termo/1/solicitarAjustes",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"termo",
+										"1",
+										"solicitarAjustes"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "aprovarTermoCoafe",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:5000/coafe/termo/13/aprovar",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"termo",
+										"13",
+										"aprovar"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "baixarTermoAluno",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/GRR20204481/download-termo",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"GRR20204481",
+										"download-termo"
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
+					]
 				},
 				{
-					"name": "baixarTermoAluno",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coafe/GRR20204481/download-termo",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"GRR20204481",
-								"download-termo"
-							]
+					"name": "TermoDeRescisao",
+					"item": [
+						{
+							"name": "listarTermosDeRescisaoPendenteCienciaCoafe",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/termoDeRescisao/pendenteCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"termoDeRescisao",
+										"pendenteCiencia"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "darCienciaTermoDeRescisaoCoafe",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/termoDeRescisao/2/darCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"termoDeRescisao",
+										"2",
+										"darCiencia"
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
+					]
 				},
 				{
-					"name": "gerarRelatorioContratante",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coafe/gerar-relatorio-empresa/102",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"gerar-relatorio-empresa",
-								"102"
-							]
+					"name": "Relatorios",
+					"item": [
+						{
+							"name": "gerarRelatorioContratante",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/gerar-relatorio-empresa/102",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"gerar-relatorio-empresa",
+										"102"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "gerarRelatorioAgenteIntegrador",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/gerar-relatorio-agenteIntegrador/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"gerar-relatorio-agenteIntegrador",
+										"1"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "gerarRelatorioEstagioSeguradoraUfpr",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/gerar-relatorio-seguradora-ufpr",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"gerar-relatorio-seguradora-ufpr"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "gerarRelatorioCertificadosDeEstagio",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/coafe/gerar-relatorio-certificados",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"coafe",
+										"gerar-relatorio-certificados"
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
-				},
-				{
-					"name": "gerarRelatorioAgenteIntegrador",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coafe/gerar-relatorio-agenteIntegrador/1",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"gerar-relatorio-agenteIntegrador",
-								"1"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "gerarRelatorioEstagioSeguradoraUfpr",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coafe/gerar-relatorio-seguradora-ufpr",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"gerar-relatorio-seguradora-ufpr"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "gerarRelatorioCertificadosDeEstagio",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/coafe/gerar-relatorio-certificados",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"coafe",
-								"gerar-relatorio-certificados"
-							]
-						}
-					},
-					"response": []
+					]
 				}
 			]
 		},
@@ -4089,158 +4564,218 @@
 			"name": "Orientadror",
 			"item": [
 				{
-					"name": "listarEstagiosDeOrientandos",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/orientador/106/estagio",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"orientador",
-								"106",
-								"estagio"
-							]
+					"name": "Estagio",
+					"item": [
+						{
+							"name": "listarEstagiosDeOrientandos",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/orientador/106/estagio",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"orientador",
+										"106",
+										"estagio"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "listarEstagiosDeOrientandosPendenteAprovacao",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/orientador/106/estagio/pendenteAprovacao",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"orientador",
+										"106",
+										"estagio",
+										"pendenteAprovacao"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "listarEstagiosDeOrientandosIndeferido",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/orientador/106/estagio/indeferido",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"orientador",
+										"106",
+										"estagio",
+										"indeferido"
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
+					]
 				},
 				{
-					"name": "listarEstagiosDeOrientandosPendenteAprovacao",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/orientador/106/estagio/pendenteAprovacao",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"orientador",
-								"106",
-								"estagio",
-								"pendenteAprovacao"
-							]
+					"name": "RelatorioDeEstagio",
+					"item": [
+						{
+							"name": "listarRelatoriosDeOrientandos",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/orientador/452/relatorioDeEstagio/",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"orientador",
+										"452",
+										"relatorioDeEstagio",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "listarRelatoriosDeOrientandosPendenteCiencia",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/orientador/452/relatorioDeEstagio/pendenteCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"orientador",
+										"452",
+										"relatorioDeEstagio",
+										"pendenteCiencia"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "darCienciaRelatorioDeEstagio",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/orientador/452/relatorioDeEstagio/7/darCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"orientador",
+										"452",
+										"relatorioDeEstagio",
+										"7",
+										"darCiencia"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "listarCertificadosDeEstagiosDoOrientador",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/orientador/3/certificadoDeEstagio/",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"orientador",
+										"3",
+										"certificadoDeEstagio",
+										""
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
+					]
 				},
 				{
-					"name": "listarEstagiosDeOrientandosIndeferido",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/orientador/106/estagio/indeferido",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"orientador",
-								"106",
-								"estagio",
-								"indeferido"
-							]
+					"name": "TermoDeRescisao",
+					"item": [
+						{
+							"name": "listarTermosDeRescisaoPendenteCienciaOrientador",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/orientador/1/termoDeRescisao/pendenteCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"orientador",
+										"1",
+										"termoDeRescisao",
+										"pendenteCiencia"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "darCienciaTermoDeRescisaoOrientador",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/orientador/3/termoDeRescisao/2/darCiencia",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"orientador",
+										"3",
+										"termoDeRescisao",
+										"2",
+										"darCiencia"
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
-				},
-				{
-					"name": "listarRelatoriosDeOrientandos",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/orientador/452/relatorioDeEstagio/",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"orientador",
-								"452",
-								"relatorioDeEstagio",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "listarRelatoriosDeOrientandosPendenteCiencia",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/orientador/452/relatorioDeEstagio/pendenteCiencia",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"orientador",
-								"452",
-								"relatorioDeEstagio",
-								"pendenteCiencia"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "darCienciaRelatorioDeEstagio",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/orientador/452/relatorioDeEstagio/7/darCiencia",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"orientador",
-								"452",
-								"relatorioDeEstagio",
-								"7",
-								"darCiencia"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "listarCertificadosDeEstagiosDoOrientador",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:5000/orientador/3/certificadoDeEstagio/",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "5000",
-							"path": [
-								"orientador",
-								"3",
-								"certificadoDeEstagio",
-								""
-							]
-						}
-					},
-					"response": []
+					]
 				}
 			]
 		}

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/CoafeREST.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/CoafeREST.java
@@ -34,6 +34,7 @@ import br.ufpr.estagio.modulo.dto.DescricaoAjustesDTO;
 import br.ufpr.estagio.modulo.dto.JustificativaDTO;
 import br.ufpr.estagio.modulo.dto.SeguradoraResumidoDTO;
 import br.ufpr.estagio.modulo.dto.TermoDeEstagioDTO;
+import br.ufpr.estagio.modulo.dto.TermoDeRescisaoDTO;
 import br.ufpr.estagio.modulo.enums.EnumTipoDocumento;
 import br.ufpr.estagio.modulo.exception.BadRequestException;
 import br.ufpr.estagio.modulo.exception.NotFoundException;
@@ -46,6 +47,7 @@ import br.ufpr.estagio.modulo.model.Contratante;
 import br.ufpr.estagio.modulo.model.Estagio;
 import br.ufpr.estagio.modulo.model.Seguradora;
 import br.ufpr.estagio.modulo.model.TermoDeEstagio;
+import br.ufpr.estagio.modulo.model.TermoDeRescisao;
 import br.ufpr.estagio.modulo.service.AgenteIntegradorService;
 import br.ufpr.estagio.modulo.service.AlunoService;
 import br.ufpr.estagio.modulo.service.CertificadoDeEstagioService;
@@ -53,6 +55,7 @@ import br.ufpr.estagio.modulo.service.ContratanteService;
 import br.ufpr.estagio.modulo.service.EstagioService;
 import br.ufpr.estagio.modulo.service.GeradorDePdfService;
 import br.ufpr.estagio.modulo.service.TermoDeEstagioService;
+import br.ufpr.estagio.modulo.service.TermoDeRescisaoService;
 
 @CrossOrigin
 @RestController
@@ -61,6 +64,9 @@ public class CoafeREST {
 
 	@Autowired
 	private TermoDeEstagioService termoDeEstagioService;
+	
+	@Autowired
+	private TermoDeRescisaoService termoDeRescisaoService;
 	
 	@Autowired
 	private AlunoService alunoService;
@@ -306,6 +312,45 @@ public class CoafeREST {
 			TermoDeEstagio termo = termoOptional.get();
 			termo = termoDeEstagioService.aprovarTermoDeEstagioCoafe(termo);
 			TermoDeEstagioDTO termoDTO = mapper.map(termo, TermoDeEstagioDTO.class);
+			return new ResponseEntity<>(termoDTO, HttpStatus.OK);
+		}
+		}catch(PocException e) {
+			e.printStackTrace();
+			throw e;
+		}catch(Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+	
+	@GetMapping("/termoDeRescisao/pendenteCiencia")
+	public ResponseEntity<List<TermoDeRescisaoDTO>> listarTermosDeRescisaoPendenteCienciaCoafe(){
+		try {
+			List<TermoDeRescisao> listaTermosDeRescisao = termoDeRescisaoService.listarTermosDeRescisaoPendenteCienciaCoafe();
+			if(listaTermosDeRescisao == null || listaTermosDeRescisao.isEmpty()) {
+				return null;
+			} else {
+				return ResponseEntity.status(HttpStatus.OK).body(listaTermosDeRescisao.stream().map(e -> mapper.map(e, TermoDeRescisaoDTO.class)).collect(Collectors.toList()));
+			}
+		}catch(PocException e) {
+			e.printStackTrace();
+			throw e;
+		}catch(Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+	
+	@PutMapping("/termoDeRescisao/{idTermo}/darCiencia")
+	public ResponseEntity<TermoDeRescisaoDTO> darCienciaTermoDeRescisao(@PathVariable Long idTermo){
+		try {
+			Optional<TermoDeRescisao> termoOptional = termoDeRescisaoService.buscarPorId(idTermo);
+		if(termoOptional.isEmpty()) {
+			throw new NotFoundException("Termo não encontrado!");
+		} else {
+			TermoDeRescisao termo = termoOptional.get();
+			termo = termoDeRescisaoService.darCienciaTermoDeRescisaoCoafe(termo);
+			TermoDeRescisaoDTO termoDTO = mapper.map(termo, TermoDeRescisaoDTO.class);
 			return new ResponseEntity<>(termoDTO, HttpStatus.OK);
 		}
 		}catch(PocException e) {

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/CoeREST.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/CoeREST.java
@@ -27,6 +27,7 @@ import br.ufpr.estagio.modulo.dto.CertificadoDeEstagioDTO;
 import br.ufpr.estagio.modulo.dto.DescricaoAjustesDTO;
 import br.ufpr.estagio.modulo.dto.JustificativaDTO;
 import br.ufpr.estagio.modulo.dto.TermoDeEstagioDTO;
+import br.ufpr.estagio.modulo.dto.TermoDeRescisaoDTO;
 import br.ufpr.estagio.modulo.enums.EnumTipoDocumento;
 import br.ufpr.estagio.modulo.exception.BadRequestException;
 import br.ufpr.estagio.modulo.exception.NotFoundException;
@@ -34,9 +35,11 @@ import br.ufpr.estagio.modulo.exception.PocException;
 import br.ufpr.estagio.modulo.model.Aluno;
 import br.ufpr.estagio.modulo.model.CertificadoDeEstagio;
 import br.ufpr.estagio.modulo.model.TermoDeEstagio;
+import br.ufpr.estagio.modulo.model.TermoDeRescisao;
 import br.ufpr.estagio.modulo.service.AlunoService;
 import br.ufpr.estagio.modulo.service.CertificadoDeEstagioService;
 import br.ufpr.estagio.modulo.service.TermoDeEstagioService;
+import br.ufpr.estagio.modulo.service.TermoDeRescisaoService;
 
 @CrossOrigin
 @RestController
@@ -51,6 +54,9 @@ public class CoeREST {
 	
 	@Autowired
 	private AlunoService alunoService;
+	
+	@Autowired
+	private TermoDeRescisaoService termoDeRescisaoService;
 		
 	@Autowired
 	private ModelMapper mapper;
@@ -240,6 +246,45 @@ public class CoeREST {
 			certificado = certificadoDeEstagioService.reprovarCertificadoDeEstagioCoe(certificado, justificativa);
 			CertificadoDeEstagioDTO certificadoDTO = mapper.map(certificado, CertificadoDeEstagioDTO.class);
 			return new ResponseEntity<>(certificadoDTO, HttpStatus.OK);
+		}
+		}catch(PocException e) {
+			e.printStackTrace();
+			throw e;
+		}catch(Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+	
+	@GetMapping("/termoDeRescisao/pendenteCiencia")
+	public ResponseEntity<List<TermoDeRescisaoDTO>> listarTermosDeRescisaoPendenteCienciaCoe(){
+		try {
+			List<TermoDeRescisao> listaTermosDeRescisao = termoDeRescisaoService.listarTermosDeRescisaoPendenteCienciaCoe();
+			if(listaTermosDeRescisao == null || listaTermosDeRescisao.isEmpty()) {
+				return null;
+			} else {
+				return ResponseEntity.status(HttpStatus.OK).body(listaTermosDeRescisao.stream().map(e -> mapper.map(e, TermoDeRescisaoDTO.class)).collect(Collectors.toList()));
+			}
+		}catch(PocException e) {
+			e.printStackTrace();
+			throw e;
+		}catch(Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+	
+	@PutMapping("/termoDeRescisao/{idTermo}/darCiencia")
+	public ResponseEntity<TermoDeRescisaoDTO> darCienciaTermoDeRescisao(@PathVariable Long idTermo){
+		try {
+			Optional<TermoDeRescisao> termoOptional = termoDeRescisaoService.buscarPorId(idTermo);
+		if(termoOptional.isEmpty()) {
+			throw new NotFoundException("Termo não encontrado!");
+		} else {
+			TermoDeRescisao termo = termoOptional.get();
+			termo = termoDeRescisaoService.darCienciaTermoDeRescisaoCoe(termo);
+			TermoDeRescisaoDTO termoDTO = mapper.map(termo, TermoDeRescisaoDTO.class);
+			return new ResponseEntity<>(termoDTO, HttpStatus.OK);
 		}
 		}catch(PocException e) {
 			e.printStackTrace();

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/CoordenacaoREST.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/CoordenacaoREST.java
@@ -27,14 +27,17 @@ import org.springframework.web.bind.annotation.RestController;
 import br.ufpr.estagio.modulo.dto.DescricaoAjustesDTO;
 import br.ufpr.estagio.modulo.dto.JustificativaDTO;
 import br.ufpr.estagio.modulo.dto.TermoDeEstagioDTO;
+import br.ufpr.estagio.modulo.dto.TermoDeRescisaoDTO;
 import br.ufpr.estagio.modulo.enums.EnumTipoDocumento;
 import br.ufpr.estagio.modulo.exception.BadRequestException;
 import br.ufpr.estagio.modulo.exception.NotFoundException;
 import br.ufpr.estagio.modulo.exception.PocException;
 import br.ufpr.estagio.modulo.model.Aluno;
 import br.ufpr.estagio.modulo.model.TermoDeEstagio;
+import br.ufpr.estagio.modulo.model.TermoDeRescisao;
 import br.ufpr.estagio.modulo.service.AlunoService;
 import br.ufpr.estagio.modulo.service.TermoDeEstagioService;
+import br.ufpr.estagio.modulo.service.TermoDeRescisaoService;
 
 @CrossOrigin
 @RestController
@@ -43,6 +46,9 @@ public class CoordenacaoREST {
 
 	@Autowired
 	private TermoDeEstagioService termoDeEstagioService;
+	
+	@Autowired
+	private TermoDeRescisaoService termoDeRescisaoService;
 	
 	@Autowired
 	private AlunoService alunoService;
@@ -330,6 +336,45 @@ public class CoordenacaoREST {
 			TermoDeEstagio termo = termoOptional.get();
 			termo = termoDeEstagioService.aprovarTermoDeEstagioCoordenacao(termo);
 			TermoDeEstagioDTO termoDTO = mapper.map(termo, TermoDeEstagioDTO.class);
+			return new ResponseEntity<>(termoDTO, HttpStatus.OK);
+		}
+		}catch(PocException e) {
+			e.printStackTrace();
+			throw e;
+		}catch(Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+	
+	@GetMapping("/termoDeRescisao/pendenteCiencia")
+	public ResponseEntity<List<TermoDeRescisaoDTO>> listarTermosDeRescisaoPendenteCienciaCoordenacao(){
+		try {
+			List<TermoDeRescisao> listaTermosDeRescisao = termoDeRescisaoService.listarTermosDeRescisaoPendenteCienciaCoordenacao();
+			if(listaTermosDeRescisao == null || listaTermosDeRescisao.isEmpty()) {
+				return null;
+			} else {
+				return ResponseEntity.status(HttpStatus.OK).body(listaTermosDeRescisao.stream().map(e -> mapper.map(e, TermoDeRescisaoDTO.class)).collect(Collectors.toList()));
+			}
+		}catch(PocException e) {
+			e.printStackTrace();
+			throw e;
+		}catch(Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+	
+	@PutMapping("/termoDeRescisao/{idTermo}/darCiencia")
+	public ResponseEntity<TermoDeRescisaoDTO> darCienciaTermoDeRescisao(@PathVariable Long idTermo){
+		try {
+			Optional<TermoDeRescisao> termoOptional = termoDeRescisaoService.buscarPorId(idTermo);
+		if(termoOptional.isEmpty()) {
+			throw new NotFoundException("Termo não encontrado!");
+		} else {
+			TermoDeRescisao termo = termoOptional.get();
+			termo = termoDeRescisaoService.darCienciaTermoDeRescisaoCoordenacao(termo);
+			TermoDeRescisaoDTO termoDTO = mapper.map(termo, TermoDeRescisaoDTO.class);
 			return new ResponseEntity<>(termoDTO, HttpStatus.OK);
 		}
 		}catch(PocException e) {

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/OrientadorREST.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/OrientadorREST.java
@@ -19,197 +19,260 @@ import org.springframework.web.bind.annotation.RestController;
 import br.ufpr.estagio.modulo.dto.CertificadoDeEstagioDTO;
 import br.ufpr.estagio.modulo.dto.EstagioDTO;
 import br.ufpr.estagio.modulo.dto.RelatorioDeEstagioDTO;
+import br.ufpr.estagio.modulo.dto.TermoDeRescisaoDTO;
 import br.ufpr.estagio.modulo.exception.NotFoundException;
 import br.ufpr.estagio.modulo.exception.PocException;
 import br.ufpr.estagio.modulo.model.CertificadoDeEstagio;
 import br.ufpr.estagio.modulo.model.Estagio;
 import br.ufpr.estagio.modulo.model.Orientador;
 import br.ufpr.estagio.modulo.model.RelatorioDeEstagio;
+import br.ufpr.estagio.modulo.model.TermoDeRescisao;
 import br.ufpr.estagio.modulo.service.CertificadoDeEstagioService;
 import br.ufpr.estagio.modulo.service.EstagioService;
 import br.ufpr.estagio.modulo.service.OrientadorService;
 import br.ufpr.estagio.modulo.service.RelatorioDeEstagioService;
+import br.ufpr.estagio.modulo.service.TermoDeRescisaoService;
 
 @CrossOrigin
 @RestController
 @RequestMapping("/orientador")
 public class OrientadorREST {
-	
+
 	@Autowired
 	private ModelMapper mapper;
-	
+
 	@Autowired
 	private EstagioService estagioService;
-	
+
 	@Autowired
 	private OrientadorService orientadorService;
-	
+
 	@Autowired
 	private RelatorioDeEstagioService relatorioDeEstagioService;
-	
+
 	@Autowired
 	private CertificadoDeEstagioService certificadoDeEstagioService;
-		
+
+	@Autowired
+	private TermoDeRescisaoService termoDeRescisaoService;
+
 	@GetMapping("/{idOrientador}/estagio")
-	public ResponseEntity<List<EstagioDTO>> listarEstagiosDeOrientandos(@PathVariable Long idOrientador){
+	public ResponseEntity<List<EstagioDTO>> listarEstagiosDeOrientandos(@PathVariable Long idOrientador) {
 		try {
 			Optional<Orientador> orientadorFind = orientadorService.buscarOrientadorPorId(idOrientador);
-			if(orientadorFind.isEmpty()) {
+			if (orientadorFind.isEmpty()) {
 				throw new NotFoundException("Orientador não encontrado!");
 			} else {
 				Orientador orientador = orientadorFind.get();
 				List<Estagio> listaEstagios = estagioService.listarEstagiosPorIdOrientador(orientador.getId());
 				List<EstagioDTO> listaDTO = new ArrayList<EstagioDTO>();
-				for(Estagio l : listaEstagios) {
+				for (Estagio l : listaEstagios) {
 					listaDTO.add(estagioService.toEstagioDTO(l));
 				}
 				return new ResponseEntity<>(listaDTO, HttpStatus.OK);
 			}
-		}catch(PocException e) {
+		} catch (PocException e) {
 			e.printStackTrace();
 			throw e;
-		}catch(Exception e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
 		}
 	}
-	
+
 	@GetMapping("/{idOrientador}/estagio/pendenteAprovacao")
-	public ResponseEntity<List<EstagioDTO>> listarEstagiosDeOrientandosPendenteAprovacao(@PathVariable Long idOrientador){
+	public ResponseEntity<List<EstagioDTO>> listarEstagiosDeOrientandosPendenteAprovacao(
+			@PathVariable Long idOrientador) {
 		try {
 			Optional<Orientador> orientadorFind = orientadorService.buscarOrientadorPorId(idOrientador);
-			if(orientadorFind.isEmpty()) {
+			if (orientadorFind.isEmpty()) {
 				throw new NotFoundException("Orientador não encontrado!");
 			} else {
 				Orientador orientador = orientadorFind.get();
-				List<Estagio> listaEstagios = estagioService.listarEstagiosPendenteAprovacaoPorIdOrientador(orientador.getId());
+				List<Estagio> listaEstagios = estagioService
+						.listarEstagiosPendenteAprovacaoPorIdOrientador(orientador.getId());
 				List<EstagioDTO> listaDTO = new ArrayList<EstagioDTO>();
-				for(Estagio l : listaEstagios) {
+				for (Estagio l : listaEstagios) {
 					listaDTO.add(estagioService.toEstagioDTO(l));
 				}
 				return new ResponseEntity<>(listaDTO, HttpStatus.OK);
 			}
-		}catch(PocException e) {
+		} catch (PocException e) {
 			e.printStackTrace();
 			throw e;
-		}catch(Exception e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
 		}
 	}
-	
+
 	@GetMapping("/{idOrientador}/estagio/indeferido")
-	public ResponseEntity<List<EstagioDTO>> listarEstagiosDeOrientandosIndeferido(@PathVariable Long idOrientador){
+	public ResponseEntity<List<EstagioDTO>> listarEstagiosDeOrientandosIndeferido(@PathVariable Long idOrientador) {
 		try {
 			Optional<Orientador> orientadorFind = orientadorService.buscarOrientadorPorId(idOrientador);
-			if(orientadorFind.isEmpty()) {
+			if (orientadorFind.isEmpty()) {
 				throw new NotFoundException("Orientador não encontrado!");
 			} else {
 				Orientador orientador = orientadorFind.get();
-				List<Estagio> listaEstagios = estagioService.listarEstagiosIndeferidosPorIdOrientador(orientador.getId());
+				List<Estagio> listaEstagios = estagioService
+						.listarEstagiosIndeferidosPorIdOrientador(orientador.getId());
 				List<EstagioDTO> listaDTO = new ArrayList<EstagioDTO>();
-				for(Estagio l : listaEstagios) {
+				for (Estagio l : listaEstagios) {
 					listaDTO.add(estagioService.toEstagioDTO(l));
 				}
 				return new ResponseEntity<>(listaDTO, HttpStatus.OK);
 			}
-		}catch(PocException e) {
+		} catch (PocException e) {
 			e.printStackTrace();
 			throw e;
-		}catch(Exception e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
 		}
 	}
-	
+
 	@GetMapping("/{idOrientador}/relatorioDeEstagio/")
-	public ResponseEntity<List<RelatorioDeEstagioDTO>> listarRelatoriosDeEstagioDeOrientandos(@PathVariable Long idOrientador){
+	public ResponseEntity<List<RelatorioDeEstagioDTO>> listarRelatoriosDeEstagioDeOrientandos(
+			@PathVariable Long idOrientador) {
 		try {
 			Optional<Orientador> orientadorFind = orientadorService.buscarOrientadorPorId(idOrientador);
-			if(orientadorFind.isEmpty()) {
+			if (orientadorFind.isEmpty()) {
 				throw new NotFoundException("Orientador não encontrado!");
 			} else {
 				Orientador orientador = orientadorFind.get();
-				List<RelatorioDeEstagio> listaRelatorios = relatorioDeEstagioService.listarRelatoriosPorIdOrientador(orientador.getId());
-			    List<RelatorioDeEstagioDTO> listaRelatoriosDTO = listaRelatorios.stream()
-			            .map(ap -> mapper.map(ap, RelatorioDeEstagioDTO.class))
-			            .collect(Collectors.toList());
-			    return ResponseEntity.ok().body(listaRelatoriosDTO);
+				List<RelatorioDeEstagio> listaRelatorios = relatorioDeEstagioService
+						.listarRelatoriosPorIdOrientador(orientador.getId());
+				List<RelatorioDeEstagioDTO> listaRelatoriosDTO = listaRelatorios.stream()
+						.map(ap -> mapper.map(ap, RelatorioDeEstagioDTO.class)).collect(Collectors.toList());
+				return ResponseEntity.ok().body(listaRelatoriosDTO);
 			}
-		}catch(PocException e) {
+		} catch (PocException e) {
 			e.printStackTrace();
 			throw e;
-		}catch(Exception e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
 		}
 	}
-	
+
 	@GetMapping("/{idOrientador}/relatorioDeEstagio/pendenteCiencia")
-	public ResponseEntity<List<RelatorioDeEstagioDTO>> listarRelatoriosDeEstagioDeOrientandosPendenteCiencia(@PathVariable Long idOrientador){
+	public ResponseEntity<List<RelatorioDeEstagioDTO>> listarRelatoriosDeEstagioDeOrientandosPendenteCiencia(
+			@PathVariable Long idOrientador) {
 		try {
 			Optional<Orientador> orientadorFind = orientadorService.buscarOrientadorPorId(idOrientador);
-			if(orientadorFind.isEmpty()) {
+			if (orientadorFind.isEmpty()) {
 				throw new NotFoundException("Orientador não encontrado!");
 			} else {
 				Orientador orientador = orientadorFind.get();
-				List<RelatorioDeEstagio> listaRelatorios = relatorioDeEstagioService.listarRelatoriosPendenteCienciaPorIdOrientador(orientador.getId());
-			    List<RelatorioDeEstagioDTO> listaRelatoriosDTO = listaRelatorios.stream()
-			            .map(ap -> mapper.map(ap, RelatorioDeEstagioDTO.class))
-			            .collect(Collectors.toList());
-			    return ResponseEntity.ok().body(listaRelatoriosDTO);
+				List<RelatorioDeEstagio> listaRelatorios = relatorioDeEstagioService
+						.listarRelatoriosPendenteCienciaPorIdOrientador(orientador.getId());
+				List<RelatorioDeEstagioDTO> listaRelatoriosDTO = listaRelatorios.stream()
+						.map(ap -> mapper.map(ap, RelatorioDeEstagioDTO.class)).collect(Collectors.toList());
+				return ResponseEntity.ok().body(listaRelatoriosDTO);
 			}
-		}catch(PocException e) {
+		} catch (PocException e) {
 			e.printStackTrace();
 			throw e;
-		}catch(Exception e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
 		}
 	}
-	
+
 	@PutMapping("/{idOrientador}/relatorioDeEstagio/{idRelatorio}/darCiencia")
-	public ResponseEntity<RelatorioDeEstagioDTO> darCienciaRelatorioDeEstagio(@PathVariable Long idOrientador, @PathVariable Long idRelatorio){
+	public ResponseEntity<RelatorioDeEstagioDTO> darCienciaRelatorioDeEstagio(@PathVariable Long idOrientador,
+			@PathVariable Long idRelatorio) {
 		try {
 			Optional<Orientador> orientadorFind = orientadorService.buscarOrientadorPorId(idOrientador);
-			if(orientadorFind.isEmpty()) {
+			if (orientadorFind.isEmpty()) {
 				throw new NotFoundException("Orientador não encontrado!");
 			}
 			Optional<RelatorioDeEstagio> relatorioFind = relatorioDeEstagioService.buscarRelatorioPorId(idRelatorio);
-			if(relatorioFind.isEmpty()) {
+			if (relatorioFind.isEmpty()) {
 				throw new NotFoundException("Relatório não encontrado!");
 			} else {
 				RelatorioDeEstagio relatorio = relatorioFind.get();
 				relatorio = relatorioDeEstagioService.darCienciaRelatorioDeEstagioOrientador(relatorio);
 				return ResponseEntity.status(HttpStatus.OK).body(mapper.map(relatorio, RelatorioDeEstagioDTO.class));
 			}
-		}catch(PocException e) {
+		} catch (PocException e) {
 			e.printStackTrace();
 			throw e;
-		}catch(Exception e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
 		}
 	}
-	
+
 	@GetMapping("/{idOrientador}/certificadoDeEstagio/")
-	public ResponseEntity<List<CertificadoDeEstagioDTO>> listarCertificadosDeEstagio(@PathVariable Long idOrientador){
+	public ResponseEntity<List<CertificadoDeEstagioDTO>> listarCertificadosDeEstagio(@PathVariable Long idOrientador) {
 		try {
 			Optional<Orientador> orientadorFind = orientadorService.buscarOrientadorPorId(idOrientador);
-			if(orientadorFind.isEmpty()) {
+			if (orientadorFind.isEmpty()) {
 				throw new NotFoundException("Orientador não encontrado!");
 			} else {
 				Orientador orientador = orientadorFind.get();
-				List<CertificadoDeEstagio> listaCertificados = certificadoDeEstagioService.listarCertificadosPorIdOrientador(orientador.getId());
-			    List<CertificadoDeEstagioDTO> listaCertificadosDTO = listaCertificados.stream()
-			            .map(ap -> mapper.map(ap, CertificadoDeEstagioDTO.class))
-			            .collect(Collectors.toList());
-			    return ResponseEntity.ok().body(listaCertificadosDTO);
+				List<CertificadoDeEstagio> listaCertificados = certificadoDeEstagioService
+						.listarCertificadosPorIdOrientador(orientador.getId());
+				List<CertificadoDeEstagioDTO> listaCertificadosDTO = listaCertificados.stream()
+						.map(ap -> mapper.map(ap, CertificadoDeEstagioDTO.class)).collect(Collectors.toList());
+				return ResponseEntity.ok().body(listaCertificadosDTO);
 			}
-		}catch(PocException e) {
+		} catch (PocException e) {
 			e.printStackTrace();
 			throw e;
-		}catch(Exception e) {
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+
+	@GetMapping("/{idOrientador}/termoDeRescisao/pendenteCiencia")
+	public ResponseEntity<List<TermoDeRescisaoDTO>> listarTermosDeRescisaoPendenteCienciaOrientador(
+			@PathVariable Long idOrientador) {
+		try {
+			Optional<Orientador> orientadorFind = orientadorService.buscarOrientadorPorId(idOrientador);
+			if (orientadorFind.isEmpty()) {
+				throw new NotFoundException("Orientador não encontrado!");
+			}
+			List<TermoDeRescisao> listaTermosDeRescisao = termoDeRescisaoService
+					.listarTermosDeRescisaoPendenteCienciaOrientador(idOrientador);
+			if (listaTermosDeRescisao == null || listaTermosDeRescisao.isEmpty()) {
+				return null;
+			} else {
+				return ResponseEntity.status(HttpStatus.OK).body(listaTermosDeRescisao.stream()
+						.map(e -> mapper.map(e, TermoDeRescisaoDTO.class)).collect(Collectors.toList()));
+			}
+		} catch (PocException e) {
+			e.printStackTrace();
+			throw e;
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+
+	@PutMapping("/{idOrientador}/termoDeRescisao/{idTermo}/darCiencia")
+	public ResponseEntity<TermoDeRescisaoDTO> darCienciaTermoDeRescisao(@PathVariable Long idOrientador,
+			@PathVariable Long idTermo) {
+		try {
+			Optional<Orientador> orientadorFind = orientadorService.buscarOrientadorPorId(idOrientador);
+			if (orientadorFind.isEmpty()) {
+				throw new NotFoundException("Orientador não encontrado!");
+			}
+			Optional<TermoDeRescisao> termoOptional = termoDeRescisaoService.buscarPorId(idTermo);
+			if (termoOptional.isEmpty()) {
+				throw new NotFoundException("Termo não encontrado!");
+			} else {
+				TermoDeRescisao termo = termoOptional.get();
+				termo = termoDeRescisaoService.darCienciaTermoDeRescisaoOrientador(termo);
+				TermoDeRescisaoDTO termoDTO = mapper.map(termo, TermoDeRescisaoDTO.class);
+				return new ResponseEntity<>(termoDTO, HttpStatus.OK);
+			}
+		} catch (PocException e) {
+			e.printStackTrace();
+			throw e;
+		} catch (Exception e) {
 			e.printStackTrace();
 			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
 		}

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/TermoDeRescisaoREST.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/TermoDeRescisaoREST.java
@@ -1,0 +1,119 @@
+package br.ufpr.estagio.modulo.controller;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.ufpr.estagio.modulo.dto.TermoDeRescisaoDTO;
+import br.ufpr.estagio.modulo.exception.NotFoundException;
+import br.ufpr.estagio.modulo.exception.PocException;
+import br.ufpr.estagio.modulo.model.TermoDeRescisao;
+import br.ufpr.estagio.modulo.service.TermoDeRescisaoService;
+
+@CrossOrigin
+@RestController
+@RequestMapping("/termoDeRescisao")
+public class TermoDeRescisaoREST {
+	
+	@Autowired
+    private TermoDeRescisaoService termoDeRescisaoService;
+	@Autowired
+	private ModelMapper mapper;
+	
+	@PostMapping("")
+	public ResponseEntity<TermoDeRescisaoDTO> inserir(@RequestBody TermoDeRescisaoDTO termo){
+		try {
+		TermoDeRescisao newTermo = termoDeRescisaoService.novo(mapper.map(termo, TermoDeRescisao.class));
+		return ResponseEntity.status(HttpStatus.CREATED).body(mapper.map(newTermo, TermoDeRescisaoDTO.class));
+		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+	    } catch(Exception e) {
+			e.printStackTrace();
+			throw new NotFoundException("Não foi possível criar um novo termo de rescisão.");
+		}
+	}
+	
+	@GetMapping("")
+	public ResponseEntity<List<TermoDeRescisaoDTO>> listarTodos(){
+		List<TermoDeRescisao> lista = termoDeRescisaoService.listarTodos();
+		if(lista.isEmpty()) {
+			throw new NotFoundException("Nenhum termo encontrado!");
+		} else {
+			return ResponseEntity.status(HttpStatus.OK).body(lista.stream().map(e -> mapper.map(e, TermoDeRescisaoDTO.class)).collect(Collectors.toList()));
+		}
+	}
+	
+	@GetMapping("/{id}")
+	public ResponseEntity<TermoDeRescisaoDTO> listarTermo(@PathVariable Long id){
+		try {
+			Optional<TermoDeRescisao> termoOptional = termoDeRescisaoService.buscarPorId(id);
+		if(termoOptional.isEmpty()) {
+			throw new NotFoundException("Termo não encontrado!");
+		} else {
+			TermoDeRescisao termo = termoOptional.get();
+			TermoDeRescisaoDTO termoDTO = mapper.map(termo, TermoDeRescisaoDTO.class);
+			return new ResponseEntity<>(termoDTO, HttpStatus.OK);
+		}
+		}catch(PocException e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}catch(Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+	
+	@PutMapping("/{id}")
+	public ResponseEntity<TermoDeRescisaoDTO> atualizar(@PathVariable Long id, @RequestBody TermoDeRescisaoDTO termo){
+		try {
+			Optional<TermoDeRescisao> termofind = termoDeRescisaoService.buscarPorId(id);
+		if(termofind.isEmpty()) {
+			throw new NotFoundException("Termo não encontrado!");
+		} else {
+			TermoDeRescisao termoAtualizado = termoDeRescisaoService.atualizarDados(termofind.get(), termo);
+			return ResponseEntity.status(HttpStatus.OK).body(mapper.map(termoAtualizado, TermoDeRescisaoDTO.class));
+		}
+		}catch(PocException e) {
+			e.printStackTrace();
+			throw e;
+		}catch(Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+		
+	@DeleteMapping("/{id}")
+	public ResponseEntity<TermoDeRescisaoDTO> delete(@PathVariable Long id){
+		try {
+			Optional<TermoDeRescisao> termofind = termoDeRescisaoService.buscarPorId(id);
+		if(termofind.isEmpty()) {
+			throw new NotFoundException("Termo de rescisão não encontrado!");
+		} else {
+			termoDeRescisaoService.deletar(id);
+			return ResponseEntity.status(HttpStatus.OK).body(null);
+		}
+		}catch(PocException e) {
+			e.printStackTrace();
+			throw e;
+		}catch(Exception e) {
+			e.printStackTrace();
+			throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro!");
+		}
+	}
+	
+}

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/dto/TermoDeRescisaoDTO.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/dto/TermoDeRescisaoDTO.java
@@ -3,17 +3,20 @@ package br.ufpr.estagio.modulo.dto;
 import java.util.ArrayList;
 import java.util.Date;
 
+import br.ufpr.estagio.modulo.enums.EnumEtapaFluxo;
 import br.ufpr.estagio.modulo.model.Estagio;
+import br.ufpr.estagio.modulo.model.PeriodoRecesso;
 
 public class TermoDeRescisaoDTO {
 
 	private long id;
 	private Estagio estagio;
+	private EnumEtapaFluxo etapaFluxo;
 	private Date dataTermino;
 	private int periodoTotalRecesso;
-	private ArrayList<PeriodoRecessoDTO> periodoRecesso;
+	private ArrayList<PeriodoRecesso> periodoRecesso;
 	private boolean cienciaOrientador;
-	private boolean cienciaCoordenador;
+	private boolean cienciaCoordenacao;
 	private boolean cienciaCOE;
 	private boolean cienciaCOAFE;
 	
@@ -22,17 +25,18 @@ public class TermoDeRescisaoDTO {
 		// TODO Auto-generated constructor stub
 	}
 
-	public TermoDeRescisaoDTO(long id, Estagio estagio, Date dataTermino, int periodoTotalRecesso,
-			ArrayList<PeriodoRecessoDTO> periodoRecesso, boolean cienciaOrientador, boolean cienciaCoordenador,
-			boolean cienciaCOE, boolean cienciaCOAFE) {
+	public TermoDeRescisaoDTO(long id, Estagio estagio, EnumEtapaFluxo etapaFluxo, Date dataTermino,
+			int periodoTotalRecesso, ArrayList<PeriodoRecesso> periodoRecesso, boolean cienciaOrientador,
+			boolean cienciaCoordenacao, boolean cienciaCOE, boolean cienciaCOAFE) {
 		super();
 		this.id = id;
 		this.estagio = estagio;
+		this.etapaFluxo = etapaFluxo;
 		this.dataTermino = dataTermino;
 		this.periodoTotalRecesso = periodoTotalRecesso;
 		this.periodoRecesso = periodoRecesso;
 		this.cienciaOrientador = cienciaOrientador;
-		this.cienciaCoordenador = cienciaCoordenador;
+		this.cienciaCoordenacao = cienciaCoordenacao;
 		this.cienciaCOE = cienciaCOE;
 		this.cienciaCOAFE = cienciaCOAFE;
 	}
@@ -53,6 +57,14 @@ public class TermoDeRescisaoDTO {
 		this.estagio = estagio;
 	}
 
+	public EnumEtapaFluxo getEtapaFluxo() {
+		return etapaFluxo;
+	}
+
+	public void setEtapaFluxo(EnumEtapaFluxo etapaFluxo) {
+		this.etapaFluxo = etapaFluxo;
+	}
+
 	public Date getDataTermino() {
 		return dataTermino;
 	}
@@ -69,11 +81,11 @@ public class TermoDeRescisaoDTO {
 		this.periodoTotalRecesso = periodoTotalRecesso;
 	}
 
-	public ArrayList<PeriodoRecessoDTO> getPeriodoRecesso() {
+	public ArrayList<PeriodoRecesso> getPeriodoRecesso() {
 		return periodoRecesso;
 	}
 
-	public void setPeriodoRecesso(ArrayList<PeriodoRecessoDTO> periodoRecesso) {
+	public void setPeriodoRecesso(ArrayList<PeriodoRecesso> periodoRecesso) {
 		this.periodoRecesso = periodoRecesso;
 	}
 
@@ -85,12 +97,12 @@ public class TermoDeRescisaoDTO {
 		this.cienciaOrientador = cienciaOrientador;
 	}
 
-	public boolean isCienciaCoordenador() {
-		return cienciaCoordenador;
+	public boolean isCienciaCoordenacao() {
+		return cienciaCoordenacao;
 	}
 
-	public void setCienciaCoordenador(boolean cienciaCoordenador) {
-		this.cienciaCoordenador = cienciaCoordenador;
+	public void setCienciaCoordenacao(boolean cienciaCoordenacao) {
+		this.cienciaCoordenacao = cienciaCoordenacao;
 	}
 
 	public boolean isCienciaCOE() {

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/enums/EnumEtapaFluxo.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/enums/EnumEtapaFluxo.java
@@ -5,6 +5,7 @@ public enum EnumEtapaFluxo {
 	Coordenacao,
 	COE,
 	COAFE,
-	Orientador
+	Orientador,
+	Ciencia
 
 }

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/TermoDeRescisao.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/model/TermoDeRescisao.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import br.ufpr.estagio.modulo.enums.EnumEtapaFluxo;
+
 import java.util.Date;
 
 import jakarta.persistence.CascadeType;
@@ -29,6 +31,9 @@ public class TermoDeRescisao implements Serializable{
 	@GeneratedValue(strategy=GenerationType.IDENTITY)
 	@Column(name = "id")
 	private long id;
+	
+	@Column(name = "etapa_fluxo")
+	private EnumEtapaFluxo etapaFluxo;
 
 	@JsonIgnore
 	@OneToOne(cascade=CascadeType.REMOVE)
@@ -48,8 +53,8 @@ public class TermoDeRescisao implements Serializable{
 	@Column(name = "ciencia_orientador")
 	private boolean cienciaOrientador;
 	
-	@Column(name = "ciencia_coordenador")
-	private boolean cienciaCoordenador;
+	@Column(name = "ciencia_coordenacao")
+	private boolean cienciaCoordenacao;
 	
 	@Column(name = "ciencia_coe")
 	private boolean cienciaCOE;
@@ -62,17 +67,18 @@ public class TermoDeRescisao implements Serializable{
 		// TODO Auto-generated constructor stub
 	}
 
-	public TermoDeRescisao(long id, Estagio estagio, Date dataTermino, int periodoTotalRecesso,
-			List<PeriodoRecesso> periodoRecesso, boolean cienciaOrientador, boolean cienciaCoordenador,
-			boolean cienciaCOE, boolean cienciaCOAFE) {
+	public TermoDeRescisao(long id, EnumEtapaFluxo etapaFluxo, Estagio estagio, Date dataTermino,
+			int periodoTotalRecesso, List<PeriodoRecesso> periodoRecesso, boolean cienciaOrientador,
+			boolean cienciaCoordenacao, boolean cienciaCOE, boolean cienciaCOAFE) {
 		super();
 		this.id = id;
+		this.etapaFluxo = etapaFluxo;
 		this.estagio = estagio;
 		this.dataTermino = dataTermino;
 		this.periodoTotalRecesso = periodoTotalRecesso;
 		this.periodoRecesso = periodoRecesso;
 		this.cienciaOrientador = cienciaOrientador;
-		this.cienciaCoordenador = cienciaCoordenador;
+		this.cienciaCoordenacao = cienciaCoordenacao;
 		this.cienciaCOE = cienciaCOE;
 		this.cienciaCOAFE = cienciaCOAFE;
 	}
@@ -83,6 +89,14 @@ public class TermoDeRescisao implements Serializable{
 
 	public void setId(long id) {
 		this.id = id;
+	}
+
+	public EnumEtapaFluxo getEtapaFluxo() {
+		return etapaFluxo;
+	}
+
+	public void setEtapaFluxo(EnumEtapaFluxo etapaFluxo) {
+		this.etapaFluxo = etapaFluxo;
 	}
 
 	public Estagio getEstagio() {
@@ -125,12 +139,12 @@ public class TermoDeRescisao implements Serializable{
 		this.cienciaOrientador = cienciaOrientador;
 	}
 
-	public boolean isCienciaCoordenador() {
-		return cienciaCoordenador;
+	public boolean isCienciaCoordenacao() {
+		return cienciaCoordenacao;
 	}
 
-	public void setCienciaCoordenador(boolean cienciaCoordenador) {
-		this.cienciaCoordenador = cienciaCoordenador;
+	public void setCienciaCoordenacao(boolean cienciaCoordenacao) {
+		this.cienciaCoordenacao = cienciaCoordenacao;
 	}
 
 	public boolean isCienciaCOE() {
@@ -147,6 +161,10 @@ public class TermoDeRescisao implements Serializable{
 
 	public void setCienciaCOAFE(boolean cienciaCOAFE) {
 		this.cienciaCOAFE = cienciaCOAFE;
+	}
+
+	public static long getSerialversionuid() {
+		return serialVersionUID;
 	}
 	
 }

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/repository/TermoDeRescisaoRepository.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/repository/TermoDeRescisaoRepository.java
@@ -1,0 +1,9 @@
+package br.ufpr.estagio.modulo.repository;
+
+import org.springframework.data.jpa.repository.*;
+
+import br.ufpr.estagio.modulo.model.TermoDeRescisao;
+
+public interface TermoDeRescisaoRepository extends JpaRepository<TermoDeRescisao, Long>{
+	
+}

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/TermoDeEstagioService.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/TermoDeEstagioService.java
@@ -27,6 +27,7 @@ import br.ufpr.estagio.modulo.model.Estagio;
 import br.ufpr.estagio.modulo.model.Orientador;
 import br.ufpr.estagio.modulo.model.PlanoDeAtividades;
 import br.ufpr.estagio.modulo.model.TermoDeEstagio;
+import br.ufpr.estagio.modulo.model.TermoDeRescisao;
 import br.ufpr.estagio.modulo.repository.AgenteIntegradorRepository;
 import br.ufpr.estagio.modulo.repository.ApoliceRepository;
 import br.ufpr.estagio.modulo.repository.CienciaCoordenacaoRepository;

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/TermoDeRescisaoService.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/TermoDeRescisaoService.java
@@ -1,0 +1,347 @@
+package br.ufpr.estagio.modulo.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import br.ufpr.estagio.modulo.dto.TermoDeRescisaoDTO;
+import br.ufpr.estagio.modulo.enums.EnumEtapaFluxo;
+import br.ufpr.estagio.modulo.enums.EnumTipoEstagio;
+import br.ufpr.estagio.modulo.model.Aluno;
+import br.ufpr.estagio.modulo.model.Estagio;
+import br.ufpr.estagio.modulo.model.TermoDeRescisao;
+import br.ufpr.estagio.modulo.repository.EstagioRepository;
+import br.ufpr.estagio.modulo.repository.TermoDeRescisaoRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+ 
+@Service
+@Transactional
+public class TermoDeRescisaoService {
+		
+	private static final String selectTermoPorTipoEstagioEtapaFluxoPendenteCienciaCoe = "SELECT t FROM TermoDeRescisao t INNER JOIN t.estagio e "
+    		+ "WHERE e.tipoEstagio = :tipoEstagio "
+    		+ "AND t.etapaFluxo = :etapaFluxo "
+    		+ "AND t.cienciaCOE = :cienciaCoe";
+	
+	private static final String selectTermoPorEtapaFluxoPendenteCienciaOrientador = "SELECT t FROM TermoDeRescisao t "
+			+ "INNER JOIN t.estagio e "
+			+ "INNER JOIN e.orientador o "
+    		+ "WHERE o.id = :idOrientador "
+    		+ "AND t.etapaFluxo = :etapaFluxo "
+    		+ "AND t.cienciaOrientador = :cienciaOrientador";
+
+	private static final String selectTermoPorEtapaFluxoPendenteCienciaCoordenacao = "SELECT t FROM TermoDeRescisao t INNER JOIN t.estagio e "
+    		+ "WHERE t.etapaFluxo = :etapaFluxo "
+    		+ "AND t.cienciaCoordenacao = :cienciaCoordenacao";
+	
+	private static final String selectTermoPorEtapaFluxoPendenteCienciaCoafe = "SELECT t FROM TermoDeRescisao t INNER JOIN t.estagio e "
+    		+ "WHERE t.etapaFluxo = :etapaFluxo "
+    		+ "AND t.cienciaCOAFE = :cienciaCoafe";
+	
+	private static final String selectTermosDeRescisaoPorAlunoPorEtapaFluxoPorCienciaCoafe = "SELECT t FROM TermoDeRescisao t "
+			+ "INNER JOIN t.estagio e "
+			+ "INNER JOIN e.aluno a "
+    		+ "WHERE t.etapaFluxo = :etapaFluxo "
+    		+ "AND t.cienciaCOAFE = :cienciaCoafe "
+			+ "AND a.id = :idAluno";
+	
+	private static final String selectTermosDeRescisaoPorAluno = "SELECT t FROM TermoDeRescisao t "
+			+ "INNER JOIN t.estagio e "
+			+ "INNER JOIN e.aluno a "
+    		+ "WHERE a.id = :idAluno";
+	
+	private static final String selectTermosDeRescisaoPorAlunoEtapaCiencia = "SELECT t FROM TermoDeRescisao t "
+			+ "INNER JOIN t.estagio e "
+			+ "INNER JOIN e.aluno a "
+    		+ "WHERE t.etapaFluxo = :etapaFluxo "
+    		+ "AND t.cienciaCOAFE = :cienciaCoafe "
+			+ "AND a.id = :idAluno";
+	
+	
+	@Autowired
+	private TermoDeRescisaoRepository termoDeRescisaoRepo;
+	
+	@Autowired
+	private EstagioRepository estagioRepo;
+	
+    @PersistenceContext
+    private EntityManager em;
+	     
+    public List<TermoDeRescisao> listarTodos() {
+        return termoDeRescisaoRepo.findAll();
+    }
+     
+    public TermoDeRescisao novo(TermoDeRescisao termoDeRescisao) {
+    	EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Aluno;
+    	termoDeRescisao.setEtapaFluxo(etapaFluxo);
+        return termoDeRescisaoRepo.save(termoDeRescisao);
+    }
+    
+    public Optional<TermoDeRescisao> buscarPorId(long id) {
+        return termoDeRescisaoRepo.findById(id);
+    }
+     
+    public TermoDeRescisao salvar(TermoDeRescisao termoDeRescisao) {
+        return termoDeRescisaoRepo.save(termoDeRescisao);
+    }
+     
+    public TermoDeRescisao atualizar(TermoDeRescisao termoDeRescisao) {
+    	return termoDeRescisaoRepo.save(termoDeRescisao);
+    }
+     
+    public void deletar(long id) {
+    	termoDeRescisaoRepo.deleteById(id);
+    }
+    
+    public TermoDeRescisao novoTermoDeRescisao(Estagio estagio) {
+    	/**
+    	 * Um estágio pode ter nenhum ou apenas uma Termo de Rescisão associado,
+    	 * desta forma, caso o Estágio já possua um Termo de Rescisão,
+    	 * retorna-se o termo de Rescisão já existente. A trava no fluxo para informar
+    	 * ao frontend caso o Estágio já possua um Termo de Rescisão associado
+    	 * é feita pela controller.
+    	 */
+		if (estagio.getTermoDeRescisao() != null) {
+			return estagio.getTermoDeRescisao();
+		}
+		
+    	TermoDeRescisao termoDeRescisao = new TermoDeRescisao();
+    	EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Aluno;
+    	termoDeRescisao.setEtapaFluxo(etapaFluxo);
+    	termoDeRescisao.setEstagio(estagio);
+    	
+    	estagio.setTermoDeRescisao(termoDeRescisao);
+    	estagioRepo.save(estagio);
+    	
+        return termoDeRescisaoRepo.save(termoDeRescisao);
+    }
+    
+    public void cancelarTermoDeRescisao(TermoDeRescisao termoDeRescisao) {
+    	/**
+    	 * Somente é possível cancelar um Termo de Rescisão caso a COAFE
+    	 * ainda não tenha dado ciência no Termo de Rescisão. Isso porque
+    	 * quando a COAFE dá ciência no Termo de Rescisão isso significada
+    	 * que o fluxo de ciência chegou ao fim. Ou seja, não é possível
+    	 * solicitar o cancelamento de um Termo de Rescisão cujo fluxo
+    	 * já chegou ao fim.
+    	 */
+    	if(termoDeRescisao.isCienciaCOAFE()) {
+    		return;
+    	}
+    	Estagio estagio = termoDeRescisao.getEstagio();
+    	termoDeRescisao.setEstagio(null);
+    	if(estagio != null) {
+        	estagio.setTermoDeRescisao(null);
+        	estagioRepo.save(estagio);
+    	}
+    	termoDeRescisaoRepo.delete(termoDeRescisao);
+    	return;    	
+    }
+
+	public TermoDeRescisao atualizarDados(TermoDeRescisao termofind, TermoDeRescisaoDTO termo) {
+		TermoDeRescisao termoAtualizado = termofind;		
+		termoAtualizado.setDataTermino(termo.getDataTermino() == null ? termoAtualizado.getDataTermino() : termo.getDataTermino());
+		termoAtualizado.setPeriodoTotalRecesso(termo.getPeriodoTotalRecesso());
+		return termoDeRescisaoRepo.save(termoAtualizado);
+	}
+
+	public List<TermoDeRescisao> listarTermosDeRescisaoPendenteCienciaCoe() {
+    	EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Ciencia;
+    	EnumTipoEstagio tipoEstagio = EnumTipoEstagio.NaoObrigatorio;
+    	boolean cienciaCoe = false;
+		        
+        TypedQuery<TermoDeRescisao> query = em.createQuery(selectTermoPorTipoEstagioEtapaFluxoPendenteCienciaCoe, TermoDeRescisao.class);
+        query.setParameter("tipoEstagio", tipoEstagio);
+        query.setParameter("etapaFluxo", etapaFluxo);
+        query.setParameter("cienciaCoe", cienciaCoe);
+        return query.getResultList();
+	}
+	
+	public List<TermoDeRescisao> listarTermosDeRescisaoPendenteCienciaOrientador(long idOrientador) {
+    	EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Ciencia;
+    	boolean cienciaOrientador = false;
+		        
+        TypedQuery<TermoDeRescisao> query = em.createQuery(selectTermoPorEtapaFluxoPendenteCienciaOrientador, TermoDeRescisao.class);
+        query.setParameter("idOrientador", idOrientador);
+        query.setParameter("etapaFluxo", etapaFluxo);
+        query.setParameter("cienciaOrientador", cienciaOrientador);
+        return query.getResultList();
+	}
+	
+	public List<TermoDeRescisao> listarTermosDeRescisaoPendenteCienciaCoordenacao() {
+    	EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Ciencia;
+    	boolean cienciaCoordenacao = false;
+		        
+        TypedQuery<TermoDeRescisao> query = em.createQuery(selectTermoPorEtapaFluxoPendenteCienciaCoordenacao, TermoDeRescisao.class);
+        query.setParameter("etapaFluxo", etapaFluxo);
+        query.setParameter("cienciaCoordenacao", cienciaCoordenacao);
+        return query.getResultList();
+	}
+	
+	public List<TermoDeRescisao> listarTermosDeRescisaoPendenteCienciaCoafe() {
+    	EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.COAFE;
+    	boolean cienciaCoafe = false;
+		        
+        TypedQuery<TermoDeRescisao> query = em.createQuery(selectTermoPorEtapaFluxoPendenteCienciaCoafe, TermoDeRescisao.class);
+        query.setParameter("etapaFluxo", etapaFluxo);
+        query.setParameter("cienciaCoafe", cienciaCoafe);
+        return query.getResultList();
+	}
+
+	public List<TermoDeRescisao> listarTermoDeRescisaoEtapaAlunoPorAluno(Aluno aluno) {
+    	EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Aluno;
+    	boolean cienciaCoafe = false;
+
+		TypedQuery<TermoDeRescisao> query = em.createQuery(selectTermosDeRescisaoPorAlunoPorEtapaFluxoPorCienciaCoafe, TermoDeRescisao.class);
+		
+		query.setParameter("etapaFluxo", etapaFluxo);
+		query.setParameter("cienciaCoafe", cienciaCoafe);
+        query.setParameter("idAluno", aluno.getId());
+		
+		return query.getResultList();
+	}
+
+	public List<TermoDeRescisao> listarTermosDeRescisaoPorAluno(Aluno aluno) {
+
+		TypedQuery<TermoDeRescisao> query = em.createQuery(selectTermosDeRescisaoPorAluno, TermoDeRescisao.class);
+		
+        query.setParameter("idAluno", aluno.getId());
+		
+		return query.getResultList();
+	}
+
+	public List<TermoDeRescisao> listarTermosDeRescisaoPorAlunoEtapaCiencia(Aluno aluno) {
+    	EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Ciencia;
+    	boolean cienciaCoafe = false;
+
+		TypedQuery<TermoDeRescisao> query = em.createQuery(selectTermosDeRescisaoPorAlunoEtapaCiencia, TermoDeRescisao.class);
+		
+		query.setParameter("etapaFluxo", etapaFluxo);
+		query.setParameter("cienciaCoafe", cienciaCoafe);
+        query.setParameter("idAluno", aluno.getId());
+		
+		return query.getResultList();
+	}
+	
+	public List<TermoDeRescisao> listarTermosDeRescisaoPorAlunoProcessoFinalizado(Aluno aluno) {
+    	EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Aluno;
+    	boolean cienciaCoafe = true;
+
+		TypedQuery<TermoDeRescisao> query = em.createQuery(selectTermosDeRescisaoPorAlunoPorEtapaFluxoPorCienciaCoafe, TermoDeRescisao.class);
+		
+		query.setParameter("etapaFluxo", etapaFluxo);
+		query.setParameter("cienciaCoafe", cienciaCoafe);
+        query.setParameter("idAluno", aluno.getId());
+		
+		return query.getResultList();
+	}
+
+	public TermoDeRescisao solicitarCienciaTermoDeRescisaoAluno(TermoDeRescisao termoDeRescisao) {
+		EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.Ciencia;
+		termoDeRescisao.setEtapaFluxo(etapaFluxo);
+		return termoDeRescisaoRepo.save(termoDeRescisao);
+	}
+
+	public TermoDeRescisao darCienciaTermoDeRescisaoCoe(TermoDeRescisao termoDeRescisao) {
+		termoDeRescisao.setCienciaCOE(true);
+		/**
+		 * O fluxo de dar ciência ao termo de rescisão ocorre de forma paralela entre os atores
+		 * COE, Coordenação e Orientador, desta forma, caso todos os 3 atores já tenham dado ciência,
+		 * no caso de estágio não obrigatório, o termo deve ser encaminhado para a ciência final
+		 * da COAFE. Caso seja um estágio obrigatório, apenas a ciência do Orientador e da
+		 * Coordenação bastam, uma vez que a COE não participa do fluxo de Estágios obrigatórios.
+		 */
+		if(termoDeRescisao.getEstagio() != null) {
+			if (termoDeRescisao.getEstagio().getTipoEstagio() != null) {
+				if(termoDeRescisao.getEstagio().getTipoEstagio() == EnumTipoEstagio.NaoObrigatorio) {
+					if(termoDeRescisao.isCienciaCOE() && termoDeRescisao.isCienciaCoordenacao() && termoDeRescisao.isCienciaOrientador()) {
+						EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.COAFE;
+						termoDeRescisao.setEtapaFluxo(etapaFluxo);
+					}
+				}else {
+					if(termoDeRescisao.isCienciaCoordenacao() && termoDeRescisao.isCienciaOrientador()) {
+						EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.COAFE;
+						termoDeRescisao.setEtapaFluxo(etapaFluxo);
+					}
+				}
+			}
+		}
+		return termoDeRescisaoRepo.save(termoDeRescisao);
+	}
+	
+	public TermoDeRescisao darCienciaTermoDeRescisaoCoordenacao(TermoDeRescisao termoDeRescisao) {
+		termoDeRescisao.setCienciaCoordenacao(true);
+		/**
+		 * O fluxo de dar ciência ao termo de rescisão ocorre de forma paralela entre os atores
+		 * COE, Coordenação e Orientador, desta forma, caso todos os 3 atores já tenham dado ciência,
+		 * no caso de estágio não obrigatório, o termo deve ser encaminhado para a ciência final
+		 * da COAFE. Caso seja um estágio obrigatório, apenas a ciência do Orientador e da
+		 * Coordenação bastam, uma vez que a COE não participa do fluxo de Estágios obrigatórios.
+		 */
+		if(termoDeRescisao.getEstagio() != null) {
+			if (termoDeRescisao.getEstagio().getTipoEstagio() != null) {
+				if(termoDeRescisao.getEstagio().getTipoEstagio() == EnumTipoEstagio.NaoObrigatorio) {
+					if(termoDeRescisao.isCienciaCOE() && termoDeRescisao.isCienciaCoordenacao() && termoDeRescisao.isCienciaOrientador()) {
+						EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.COAFE;
+						termoDeRescisao.setEtapaFluxo(etapaFluxo);
+					}
+				}else {
+					if(termoDeRescisao.isCienciaCoordenacao() && termoDeRescisao.isCienciaOrientador()) {
+						EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.COAFE;
+						termoDeRescisao.setEtapaFluxo(etapaFluxo);
+					}
+				}
+			}
+		}
+		return termoDeRescisaoRepo.save(termoDeRescisao);
+	}
+	
+	public TermoDeRescisao darCienciaTermoDeRescisaoOrientador(TermoDeRescisao termoDeRescisao) {
+		termoDeRescisao.setCienciaOrientador(true);
+		/**
+		 * O fluxo de dar ciência ao termo de rescisão ocorre de forma paralela entre os atores
+		 * COE, Coordenação e Orientador, desta forma, caso todos os 3 atores já tenham dado ciência,
+		 * no caso de estágio não obrigatório, o termo deve ser encaminhado para a ciência final
+		 * da COAFE. Caso seja um estágio obrigatório, apenas a ciência do Orientador e da
+		 * Coordenação bastam, uma vez que a COE não participa do fluxo de Estágios obrigatórios.
+		 */
+		if(termoDeRescisao.getEstagio() != null) {
+			if (termoDeRescisao.getEstagio().getTipoEstagio() != null) {
+				if(termoDeRescisao.getEstagio().getTipoEstagio() == EnumTipoEstagio.NaoObrigatorio) {
+					if(termoDeRescisao.isCienciaCOE() && termoDeRescisao.isCienciaCoordenacao() && termoDeRescisao.isCienciaOrientador()) {
+						EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.COAFE;
+						termoDeRescisao.setEtapaFluxo(etapaFluxo);
+					}
+				}else {
+					if(termoDeRescisao.isCienciaCoordenacao() && termoDeRescisao.isCienciaOrientador()) {
+						EnumEtapaFluxo etapaFluxo = EnumEtapaFluxo.COAFE;
+						termoDeRescisao.setEtapaFluxo(etapaFluxo);
+					}
+				}
+			}
+		}
+		return termoDeRescisaoRepo.save(termoDeRescisao);
+	}
+	
+	public TermoDeRescisao darCienciaTermoDeRescisaoCoafe(TermoDeRescisao termoDeRescisao) {
+		/**
+		 * Quando a COAFE dá ciência no Termo de Recisão o fluxo se encerra.
+		 * A forma de sinalizar que o fluxo encerrou é mudando o denifindo a etapaFluxo como Aluno.
+		 * Além disto, uma vez que COAFE dá ciência no Termo de Rescisão a data de término
+		 * do Estágio é atualizada conforme data de término informada no Termo de Rescisão.
+		 */
+		termoDeRescisao.setCienciaCOAFE(true);
+		termoDeRescisao.setEtapaFluxo(EnumEtapaFluxo.Aluno);
+		if(termoDeRescisao.getEstagio() != null) {
+			termoDeRescisao.getEstagio().setDataTermino(termoDeRescisao.getDataTermino());
+			estagioRepo.save(termoDeRescisao.getEstagio());
+		}
+		return termoDeRescisaoRepo.save(termoDeRescisao);
+	}
+	
+}


### PR DESCRIPTION
Implementação do fluxo de termo de rescisão passando por todos os atores. Histórias de usuário implementadas:

Épico 17:
- HU117 - Sendo aluno, quero preencher o termo de rescisão, para poder baixar o documento preenchido;
- HU120 - Sendo aluno, quero visualizar o status do termo de rescisão, para ter conhecimento do andamento do processo de rescisão;
- HU121 - Sendo aluno, quero realizar o cancelamento de termo de rescisão em andamento, para poder cancelar a solicitação de rescisão;
- HU122 - Sendo aluno, quero consultar os meus termos de rescisão, para poder visualizar informações sobre eles.

Épico 18:
- HU123 - Sendo orientador, quero poder listar os termos de rescisão em aberto, para poder dar ciência;
- HU124 - Sendo orientador, quero dar ciência no termo de rescisão, para que o processo de encerramento do estágio siga adiante.

Épico 19:
- HU125 - Sendo quero poder listar os termos de rescisão em aberto, para poder dar ciência;
- HU126 - Sendo quero dar ciência no termo de rescisão, para que o processo de encerramento do estágio siga adiante.

Épico 20:
- HU127 - Sendo coordenação, quero poder listar os termos de rescisão em aberto, para poder dar ciência;
- HU128 - Sendo coordenação, quero dar ciência no termo de rescisão, para que o processo de encerramento do estágio siga adiante.

Épico 21:
- HU129 - Sendo COAFE, quero poder listar os termos de rescisão em aberto, para poder dar ciência;
- HU130 - Sendo COAFE, quero dar ciência no termo de rescisão, para que a rescisão do termo de compromisso seja efetivada e o estágio seja encerrado;
- HU131 - Sendo COAFE, quero consolidar o termo de rescisão ao termo de compromisso, para que as informações fiquem centralizadas.