### PR TITLE
backend: Fix listagem contratantes somente PJ

### DIFF
--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/repository/ContratanteRepository.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/repository/ContratanteRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import br.ufpr.estagio.modulo.enums.EnumTipoContratante;
 import br.ufpr.estagio.modulo.model.Contratante;
 
 public interface ContratanteRepository extends JpaRepository<Contratante, Long> {
@@ -18,5 +19,10 @@ public interface ContratanteRepository extends JpaRepository<Contratante, Long> 
 	List<Contratante> findByNomeContainingIgnoreCase(String nomeContratante);
 
 	List<Contratante> findByNomeStartsWithIgnoreCase(String nomeContratante);
+
+	List<Contratante> findByTipo(EnumTipoContratante tipoContratante);
+
+	List<Contratante> findByNomeContainingIgnoreCaseAndTipo(String nomeContratante,
+			EnumTipoContratante tipoContratante);
 	
 }

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/ContratanteService.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/ContratanteService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import br.ufpr.estagio.modulo.enums.EnumTipoContratante;
 import br.ufpr.estagio.modulo.model.Contratante;
 import br.ufpr.estagio.modulo.model.Endereco;
 import br.ufpr.estagio.modulo.repository.ContratanteRepository;
@@ -32,7 +33,8 @@ public class ContratanteService {
 	}
 
 	public List<Contratante> listarContratantes() {
-		return contratanteRepo.findAll();
+		EnumTipoContratante tipoContratante = EnumTipoContratante.PessoaJuridica;
+		return contratanteRepo.findByTipo(tipoContratante);
 	}
 
 	public Contratante atualizarContratante(Contratante contratanteAtualizado) {
@@ -68,7 +70,9 @@ public class ContratanteService {
 	}
 
 	public List<Contratante> buscarPorNomeContendo(String nomeContratante) {
-		return contratanteRepo.findByNomeContainingIgnoreCase(nomeContratante);
+		EnumTipoContratante tipoContratante = EnumTipoContratante.PessoaJuridica;
+		return contratanteRepo.findByNomeContainingIgnoreCaseAndTipo(nomeContratante, tipoContratante);
+		//return contratanteRepo.findByNomeContainingIgnoreCase(nomeContratante);
 	}
 
 	public List<Contratante> buscarContratantePorNomeComecandoPor(String nomeContratante) {


### PR DESCRIPTION
Agora as seguintes rotas de listagem de contratantes retornam na lista apenas pessoas jurídicas:
- Contratante > listarContratantes
- Contratante > listarContratantesPorNomeContendo