### PR TITLE
backend: bug fix - Deletar apólice

### DIFF
--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/ApoliceREST.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/controller/ApoliceREST.java
@@ -207,6 +207,9 @@ public class ApoliceREST {
 	    } catch (InvalidFieldException ex) {
 	        ErrorResponse response = new ErrorResponse(ex.getMessage());
 	        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+	    } catch (RuntimeException ex) {
+	        ErrorResponse response = new ErrorResponse(ex.getMessage());
+	        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
 	    } catch (Exception e) {
 	        e.printStackTrace();
 	        throw new PocException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro ao excluir agente integrador!");

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/ApoliceService.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/ApoliceService.java
@@ -54,7 +54,20 @@ public class ApoliceService {
 	    Optional<Apolice> apoliceOptional = apoliceRepository.findById(apolice.getId());
 	    if (apoliceOptional.isPresent()) {
 	        Apolice apoliceExistente = apoliceOptional.get();
-	        apoliceRepository.delete(apoliceExistente);
+	        if (apoliceExistente.getEstagio() != null || apoliceExistente.getTermoDeEstagio() != null) {
+	        	throw new RuntimeException("Não é possível deletar uma apólice que esteja associada a um Estágio ou a um Termo de Estágio.");
+	        }else {
+	        	Seguradora seguradora = apoliceExistente.getSeguradora();
+	        	if(seguradora != null) {
+	        		List<Apolice> listaApolices = seguradora.getApolice();
+	        		if (listaApolices != null) {
+	        			listaApolices.remove(apoliceExistente);
+	        			seguradora.setApolice(listaApolices);
+	        		}
+	        	}
+	        	apoliceExistente.setSeguradora(null);
+	        	apoliceRepository.delete(apoliceExistente);
+	        }
 	    } else {
 	    	throw new RuntimeException("Não foi encontrado uma apólice com o ID informado.");
 	    }


### PR DESCRIPTION
Realizado correção do bug que estava ocasionando a deleção da seguradora realizar a deleção de uma apólice. Além disso, foi adicionado uma verificação de um tratamento de exceção para não permitir a deleção de apólice caso ela já esteja associada a um Estágio ou Termo De Estágio.