### PR TITLE
backend: procedures e scheduler status estágio

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ Criando imagem do banco em docker:
 docker run --name tcc -e MYSQL_ROOT_PASSWORD=poc -e MYSQL_DATABASE=poc -e MYSQL_USER=poc -e MYSQL_PASSWORD=poc -p 3306:3306 -d mariadb:latest
 ```
 
+### Configurações do Banco
+
+O usuário que aplicação utilizar para acessar o banco precisa ter os seguintes privilégios:
+- Usage
+- Event
+
+O privilégio Event é necessário pois a aplicação irá criar procedures no banco quando for inicializada e além das procedures também irá criar um scheduler event para executar as procedures de tempo em tempo.
+
+Além disto, também é necessário que o parâmetro global event_scheduler esteja habilitado no banco para que o scheduler execute. Para habilitar o event_scheduler no banco a seguinte query SQL deve ser executada no banco:
+
+```
+SET GLOBAL event_scheduler = ON;
+```
+
 ## Backend
 
 Necessita:

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/PocServiceApplication.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/PocServiceApplication.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import com.itextpdf.html2pdf.HtmlConverter;
 
 import br.ufpr.estagio.modulo.service.GeradorDePdfService;
+import br.ufpr.estagio.modulo.service.MariaDBInitializerService;
 import jakarta.annotation.PostConstruct;
 
 @SpringBootApplication
@@ -19,6 +20,9 @@ public class PocServiceApplication {
 	
 	@Autowired
 	private GeradorDePdfService geradorDePdfService;
+	
+    @Autowired
+    private MariaDBInitializerService mariaDBInitializer;
 	
 	public static void main(String[] args) {
 		SpringApplication.run(PocServiceApplication.class, args);
@@ -38,6 +42,10 @@ public class PocServiceApplication {
 	    if (!diretorio.exists()) {
 	        diretorio.mkdirs();
 	    }
+	    
+	    mariaDBInitializer.createProcedureUpdateStatusEstagioIniciado();
+	    mariaDBInitializer.createProcedureUpdateStatusConcluido();
+	    mariaDBInitializer.createEventUpdateStatusEstagio();
 	}
 
 }

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/enums/EnumStatusEstagio.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/enums/EnumStatusEstagio.java
@@ -6,7 +6,7 @@ public enum EnumStatusEstagio {
 	Aprovado,
 	Iniciado,
 	Concluido,
-	Cancelado,
+	Cancelado,	
 	Rescindido,
 	Reprovado
 

--- a/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/MariaDBInitializerService.java
+++ b/backend/estagio-poc/src/main/java/br/ufpr/estagio/modulo/service/MariaDBInitializerService.java
@@ -1,0 +1,59 @@
+package br.ufpr.estagio.modulo.service;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class MariaDBInitializerService {
+	
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional
+    public void createProcedureUpdateStatusEstagioIniciado() {
+        Query query = entityManager.createNativeQuery(
+            "CREATE PROCEDURE IF NOT EXISTS update_estagio_status_para_iniciado() " +
+            "BEGIN " +
+            "  UPDATE estagio " +
+            "  SET status_estagio = 3 " +
+            "  WHERE data_inicio <= NOW() " +
+            "AND data_termino >= NOW() " +
+            "AND status_estagio = 2; " +
+            "END"
+        );
+        query.executeUpdate();
+    }
+
+    @Transactional
+    public void createProcedureUpdateStatusConcluido() {
+        Query query = entityManager.createNativeQuery(
+            "CREATE PROCEDURE IF NOT EXISTS update_estagio_status_para_concluido() " +
+            "BEGIN " +
+            "  UPDATE estagio " +
+            "  SET status_estagio = 4 " +
+            "  WHERE data_termino <= NOW() " +
+            "AND status_estagio = 3; " +
+            "END"
+        );
+        query.executeUpdate();
+    }
+    
+    @Transactional
+    public void createEventUpdateStatusEstagio() {
+        Query query = entityManager.createNativeQuery(
+        	"CREATE EVENT IF NOT EXISTS update_status_estagio_event " +
+        	"ON SCHEDULE EVERY 5 MINUTE " +
+        	"DO " +
+        	"BEGIN " +
+        	"  CALL update_estagio_status_para_iniciado(); " +
+        	"  CALL update_estagio_status_para_concluido(); " +
+        	"END"
+        );
+        query.executeUpdate();
+    }
+    
+}


### PR DESCRIPTION
Adicionado a criação de duas procedures via JPA para alterar o status do estágio para Iniciado e para Concluido, além disto, foi adicionado a criação de um scheduler também via JPA para executar essas duas procedures de tempos em tempos. O objetivo é que com base na data de inicio do estágio o status do estágio seja automaticamente alterado para Iniciado. O mesmo para a data de termino do estágio, tendo a alteração do status para Concluido.